### PR TITLE
chore: adapt orogen to use helper functions from radar_base

### DIFF
--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -60,8 +60,6 @@ void EchoesToFrameConverterTask::updateHook()
             m_current_sweep_size = radar_echo.sweep_length;
             m_current_num_angles = 2 * M_PI / abs(radar_echo.step_angle.getRad());
             m_current_range = radar_echo.range;
-            m_echoes =
-                std::vector<uint8_t>(m_current_sweep_size * m_current_num_angles, 0);
             updateLookUpTable(config);
         }
         addEchoesToFrame(radar_echo, yaw_correction);
@@ -106,6 +104,7 @@ void EchoesToFrameConverterTask::addEchoesToFrame(Radar const& echo,
 
 void EchoesToFrameConverterTask::publishFrame()
 {
+    m_cv_frame = 0;
     LOG_INFO_S << "Creating a frame...";
     drawImageFromEchoes(m_echoes, m_current_sweep_size, *m_lut, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -7,6 +7,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace radar_base;
+using namespace helpers;
 using namespace cv;
 using namespace base::samples::frame;
 EchoesToFrameConverterTask::EchoesToFrameConverterTask(std::string const& name)
@@ -51,12 +52,16 @@ void EchoesToFrameConverterTask::updateHook()
 
     Radar radar_echo;
     while (_echo.read(radar_echo, false) == RTT::NewData) {
-        if (m_current_sweep_size != radar_echo.sweep_length ||
-            m_current_num_angles != (2 * M_PI / abs(radar_echo.step_angle.getRad())) ||
+        if (!m_lut->hasMatchingConfiguration(m_current_num_angles,
+                m_current_sweep_size,
+                config.beam_width,
+                config.output_image_size) ||
             m_current_range != radar_echo.range) {
             m_current_sweep_size = radar_echo.sweep_length;
             m_current_num_angles = 2 * M_PI / abs(radar_echo.step_angle.getRad());
             m_current_range = radar_echo.range;
+            m_echoes =
+                std::vector<uint8_t>(m_current_sweep_size * m_current_num_angles, 0);
             updateLookUpTable(config);
         }
         addEchoesToFrame(radar_echo, yaw_correction);
@@ -96,38 +101,13 @@ void EchoesToFrameConverterTask::addEchoesToFrame(Radar const& echo,
     base::Angle yaw_correction)
 {
     LOG_INFO_S << "Adding echoes...";
-    double angle = (echo.start_heading + yaw_correction).getRad();
-    if (angle < 0) {
-        angle = 2 * M_PI + angle;
-    }
-    int start_angle_unit = round(angle / abs(echo.step_angle.getRad()));
-    int angles_in_a_frame = round(2 * M_PI / abs(echo.step_angle.getRad()));
-    int signal = abs(echo.step_angle.getRad()) / echo.step_angle.getRad();
-    for (int current_angle = 0;
-         current_angle < static_cast<int>(echo.sweep_timestamps.size());
-         current_angle++) {
-
-        int echo_position =
-            (start_angle_unit + current_angle * signal) % angles_in_a_frame;
-        if (echo_position < 0) {
-            echo_position += angles_in_a_frame;
-        }
-        std::copy(echo.sweep_data.begin() + current_angle * echo.sweep_length,
-            echo.sweep_data.begin() + (current_angle + 1) * echo.sweep_length,
-            m_echoes.begin() + echo.sweep_length * echo_position);
-    }
+    updateEchoes(echo, yaw_correction, m_echoes);
 }
 
 void EchoesToFrameConverterTask::publishFrame()
 {
-    m_cv_frame = 0;
     LOG_INFO_S << "Creating a frame...";
-    for (long i = 0; i < static_cast<long>(m_echoes.size()); i++) {
-        m_lut->updateImage(m_cv_frame,
-            i / m_current_sweep_size,
-            i % m_current_sweep_size,
-            m_echoes.at(i));
-    }
+    drawImageFromEchoes(m_echoes, m_current_sweep_size, *m_lut, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";
     Mat output;
     cv::cvtColor(m_cv_frame, output, cv::COLOR_BGR2GRAY);

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -52,15 +52,18 @@ void EchoesToFrameConverterTask::updateHook()
 
     Radar radar_echo;
     while (_echo.read(radar_echo, false) == RTT::NewData) {
+        m_current_sweep_size = radar_echo.sweep_length;
+        m_current_num_angles = 2 * M_PI / abs(radar_echo.step_angle.getRad());
         if (!m_lut->hasMatchingConfiguration(m_current_num_angles,
                 m_current_sweep_size,
                 config.beam_width,
-                config.output_image_size) ||
-            m_current_range != radar_echo.range) {
-            m_current_sweep_size = radar_echo.sweep_length;
-            m_current_num_angles = 2 * M_PI / abs(radar_echo.step_angle.getRad());
-            m_current_range = radar_echo.range;
+                config.output_image_size)) {
             updateLookUpTable(config);
+        }
+        if (m_current_range != radar_echo.range) {
+            m_current_range = radar_echo.range;
+            m_echoes =
+                std::vector<uint8_t>(m_current_sweep_size * m_current_num_angles, 0);
         }
         addEchoesToFrame(radar_echo, yaw_correction);
     }

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -7,7 +7,6 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace radar_base;
-using namespace helpers;
 using namespace cv;
 using namespace base::samples::frame;
 EchoesToFrameConverterTask::EchoesToFrameConverterTask(std::string const& name)
@@ -102,14 +101,14 @@ void EchoesToFrameConverterTask::addEchoesToFrame(Radar const& echo,
     base::Angle yaw_correction)
 {
     LOG_INFO_S << "Adding echoes...";
-    updateEchoes(echo, yaw_correction, m_echoes);
+    Radar::updateEchoes(echo, yaw_correction, m_echoes);
 }
 
 void EchoesToFrameConverterTask::publishFrame()
 {
     m_cv_frame = 0;
     LOG_INFO_S << "Creating a frame...";
-    drawImageFromEchoes(m_echoes, *m_lut, m_cv_frame);
+    (*m_lut).drawImageFromEchoes(m_echoes, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";
     Mat output;
     cv::cvtColor(m_cv_frame, output, cv::COLOR_BGR2GRAY);

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -108,7 +108,7 @@ void EchoesToFrameConverterTask::publishFrame()
 {
     m_cv_frame = 0;
     LOG_INFO_S << "Creating a frame...";
-    (*m_lut).drawImageFromEchoes(m_echoes, m_cv_frame);
+    m_lut->drawImageFromEchoes(m_echoes, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";
     Mat output;
     cv::cvtColor(m_cv_frame, output, cv::COLOR_BGR2GRAY);

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -106,7 +106,7 @@ void EchoesToFrameConverterTask::publishFrame()
 {
     m_cv_frame = 0;
     LOG_INFO_S << "Creating a frame...";
-    drawImageFromEchoes(m_echoes, m_current_sweep_size, *m_lut, m_cv_frame);
+    drawImageFromEchoes(m_echoes, *m_lut, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";
     Mat output;
     cv::cvtColor(m_cv_frame, output, cv::COLOR_BGR2GRAY);

--- a/tasks/EchoesToFrameConverterTask.hpp
+++ b/tasks/EchoesToFrameConverterTask.hpp
@@ -5,7 +5,6 @@
 
 #include "radar_base/EchoToImageLUT.hpp"
 #include "radar_base/EchoesToFrameConverterTaskBase.hpp"
-#include "radar_base/Helpers.hpp"
 #include <base/Time.hpp>
 #include <base/samples/Frame.hpp>
 #include <memory>

--- a/tasks/EchoesToFrameConverterTask.hpp
+++ b/tasks/EchoesToFrameConverterTask.hpp
@@ -5,6 +5,7 @@
 
 #include "radar_base/EchoToImageLUT.hpp"
 #include "radar_base/EchoesToFrameConverterTaskBase.hpp"
+#include "radar_base/Helpers.hpp"
 #include <base/Time.hpp>
 #include <base/samples/Frame.hpp>
 #include <memory>


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-radar_base/pull/9

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

Change the radar orogen to use helper functions

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Before the changes:
![image](https://github.com/tidewise/drivers-orogen-radar_base/assets/77353710/096b4430-a4ce-48c5-b67e-3577a7e51ad8)

After the changes:
![image](https://github.com/tidewise/drivers-orogen-radar_base/assets/77353710/09255901-6723-4749-abb5-c8a45fab23e6)

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
