### PR TITLE
fix(tests): use time from radar echo

### DIFF
--- a/test/echoes_to_frame_converter_task_test.rb
+++ b/test/echoes_to_frame_converter_task_test.rb
@@ -135,7 +135,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
         (samples / 2).times { input_inverted.concat(pattern2 + pattern1) }
         @echo = Types.radar_base.Radar.new
         @echo = {
-            timestamp: Time.now,
+            time: Time.now,
             range: 2.0,
             step_angle: {
                 rad: 2 * Math::PI / samples
@@ -150,7 +150,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
 
         @echo_inverted = Types.radar_base.Radar.new
         @echo_inverted = {
-            timestamp: Time.now,
+            time: Time.now,
             range: 2.0,
             step_angle: {
                 rad: -2 * Math::PI / samples
@@ -165,7 +165,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
 
         @echo_part1 = Types.radar_base.Radar.new
         @echo_part1 = {
-            timestamp: Time.now,
+            time: Time.now,
             range: 2.0,
             step_angle: {
                 rad: 2 * Math::PI / (2 * samples)
@@ -180,7 +180,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
 
         @echo_part2 = Types.radar_base.Radar.new
         @echo_part2 = {
-            timestamp: Time.now,
+            time: Time.now,
             range: 2.0,
             step_angle: {
                 rad: 2 * Math::PI / (2 * samples)
@@ -194,7 +194,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
         }
         @echo_rotation = Types.radar_base.Radar.new
         @echo_rotation = {
-            timestamp: Time.now,
+            time: Time.now,
             range: 2.0,
             step_angle: {
                 rad: 2 * Math::PI / (2 * samples)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-radar_base/pull/10


# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
[sc-43802]
- [ ] [Shortcut](http://) -->
The timestamp field changed to time
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
