### PR TITLE
fix(test): starts and outputs single radar data

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -7,6 +7,7 @@
   <url>http://</url>
   <logo>http://</logo>
   <depend package="base/cmake" />
+  <depend package="drivers/orogen/aggregator" />
   <depend package="drivers/radar_base" />
   <depend package="opencv" />
   <depend package="base/logging" />

--- a/radar_base.orogen
+++ b/radar_base.orogen
@@ -20,5 +20,12 @@ task_context "EchoesToFrameConverterTask" do
     output_port "frame", ro_ptr("base/samples/frame/Frame")
     output_port "range", "double"
 
+    stream_aligner do
+        align_port "echo", 0, "timestamp"
+        align_port "sensor2ref_pose", 0
+
+        max_latency 1
+    end
+
     port_driven
 end

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -26,52 +26,77 @@ bool EchoesToFrameConverterTask::configureHook()
 {
     if (!EchoesToFrameConverterTaskBase::configureHook())
         return false;
-    auto config = _export_config.get();
-    configureOutput(config);
-    updateLookUpTable(config);
+
+    m_export_config = _export_config.get();
+    configureOutput(m_export_config);
+
     return true;
 }
 bool EchoesToFrameConverterTask::startHook()
 {
     if (!EchoesToFrameConverterTaskBase::startHook())
         return false;
+
+    m_yaw_correction = base::Angle::unknown();
+    m_current_range = base::unknown<float>();
+    m_lut.reset(nullptr);
+    m_frame_output_deadline = base::Time::now() + m_export_config.time_between_frames;
+
     return true;
-    m_last_sample = base::Time::now();
 }
+
 void EchoesToFrameConverterTask::updateHook()
 {
     EchoesToFrameConverterTaskBase::updateHook();
-    auto config = _export_config.get();
 
-    base::Angle yaw_correction = base::Angle::fromRad(0);
-    base::samples::RigidBodyState sensor2ref_pose;
-    if (_sensor2ref_pose.read(sensor2ref_pose) != RTT::NoData) {
-        yaw_correction = base::Angle::fromRad(sensor2ref_pose.getYaw());
-    }
-
-    Radar radar_echo;
-    while (_echo.read(radar_echo, false) == RTT::NewData) {
-        m_current_sweep_size = radar_echo.sweep_length;
-        m_current_num_angles = 2 * M_PI / abs(radar_echo.step_angle.getRad());
-        if (!m_lut->hasMatchingConfiguration(m_current_num_angles,
-                m_current_sweep_size,
-                config.beam_width,
-                config.output_image_size)) {
-            updateLookUpTable(config);
-        }
-        if (m_current_range != radar_echo.range) {
-            m_current_range = radar_echo.range;
-            m_echoes =
-                std::vector<uint8_t>(m_current_sweep_size * m_current_num_angles, 0);
-        }
-        addEchoesToFrame(radar_echo, yaw_correction);
-    }
-
-    auto deadline = m_last_sample + config.time_between_frames;
-    if (base::Time::now() > deadline) {
+    base::Time now = base::Time::now();
+    if (m_lut && now >= m_frame_output_deadline) {
+        m_frame_output_deadline = now + m_export_config.time_between_frames;
         publishFrame();
-        m_last_sample = base::Time::now();
     }
+}
+
+void EchoesToFrameConverterTask::echoCallback(const base::Time& ts,
+    const radar_base::Radar& echo_sample)
+{
+    if (echo_sample.sweep_data.empty() || base::isUnknown(m_yaw_correction)) {
+        return;
+    }
+
+    unsigned int current_sweep_size = echo_sample.sweep_length;
+    unsigned int current_num_angles = 2 * M_PI / abs(echo_sample.step_angle.getRad());
+
+    if (!m_lut) { // initialization
+        updateLookUpTable(current_num_angles, current_sweep_size, m_export_config);
+        m_current_range = echo_sample.range;
+    }
+    else {
+        if (!m_lut->hasMatchingConfiguration(current_num_angles,
+                current_sweep_size,
+                m_export_config.beam_width,
+                m_export_config.output_image_size)) {
+            updateLookUpTable(current_num_angles, current_sweep_size, m_export_config);
+        }
+
+        if (m_current_range != echo_sample.range) {
+            m_current_range = echo_sample.range;
+            resetEchoMemory(current_sweep_size * current_num_angles);
+        }
+    }
+
+    addEchoesToFrame(echo_sample, m_yaw_correction);
+}
+
+void EchoesToFrameConverterTask::sensor2ref_poseCallback(const base::Time& ts,
+    const base::samples::RigidBodyState& sensor2ref_pose_sample)
+{
+    m_yaw_correction = base::Angle::fromRad(sensor2ref_pose_sample.getYaw());
+}
+
+void EchoesToFrameConverterTask::resetEchoMemory(std::size_t size)
+{
+    m_echoes.resize(size);
+    m_echoes.assign(size, 0);
 }
 
 void EchoesToFrameConverterTask::errorHook()
@@ -87,14 +112,16 @@ void EchoesToFrameConverterTask::cleanupHook()
     EchoesToFrameConverterTaskBase::cleanupHook();
 }
 
-void EchoesToFrameConverterTask::updateLookUpTable(RadarFrameExportConfig config)
+void EchoesToFrameConverterTask::updateLookUpTable(unsigned int num_sweeps,
+    unsigned int sweep_size,
+    RadarFrameExportConfig const& config)
 {
     LOG_INFO_S << "Updating LookUpTable";
-    m_lut.reset(new EchoToImageLUT(m_current_num_angles,
-        m_current_sweep_size,
+    m_lut.reset(new EchoToImageLUT(num_sweeps,
+        sweep_size,
         config.beam_width,
         config.output_image_size));
-    m_echoes = std::vector<uint8_t>(m_current_sweep_size * m_current_num_angles, 0);
+    resetEchoMemory(num_sweeps * sweep_size);
 }
 
 void EchoesToFrameConverterTask::addEchoesToFrame(Radar const& echo,
@@ -121,7 +148,7 @@ void EchoesToFrameConverterTask::publishFrame()
     _frame.write(m_output_frame);
 }
 
-void EchoesToFrameConverterTask::configureOutput(RadarFrameExportConfig config)
+void EchoesToFrameConverterTask::configureOutput(RadarFrameExportConfig const& config)
 {
     LOG_INFO_S << "Configuring output";
     m_cv_frame = Mat::zeros(config.output_image_size, config.output_image_size, CV_8UC3);

--- a/tasks/EchoesToFrameConverterTask.cpp
+++ b/tasks/EchoesToFrameConverterTask.cpp
@@ -137,12 +137,12 @@ void EchoesToFrameConverterTask::publishFrame()
     LOG_INFO_S << "Creating a frame...";
     m_lut->drawImageFromEchoes(m_echoes, m_cv_frame);
     LOG_INFO_S << "Publishing Frame";
-    Mat output;
-    cv::cvtColor(m_cv_frame, output, cv::COLOR_BGR2GRAY);
+    cv::cvtColor(m_cv_frame, m_cv_frame_monochrome, cv::COLOR_BGR2GRAY);
     Frame* out_frame = m_output_frame.write_access();
     out_frame->time = base::Time::now();
     out_frame->received_time = out_frame->time;
-    out_frame->setImage(output.data, output.total() * output.elemSize());
+    out_frame->setImage(m_cv_frame_monochrome.data,
+        m_cv_frame_monochrome.total() * m_cv_frame_monochrome.elemSize());
     out_frame->setStatus(STATUS_VALID);
     m_output_frame.reset(out_frame);
     _frame.write(m_output_frame);
@@ -152,6 +152,8 @@ void EchoesToFrameConverterTask::configureOutput(RadarFrameExportConfig const& c
 {
     LOG_INFO_S << "Configuring output";
     m_cv_frame = Mat::zeros(config.output_image_size, config.output_image_size, CV_8UC3);
+    m_cv_frame_monochrome =
+        Mat::zeros(config.output_image_size, config.output_image_size, CV_8UC1);
 
     Frame* frame = new Frame(config.output_image_size,
         config.output_image_size,

--- a/tasks/EchoesToFrameConverterTask.hpp
+++ b/tasks/EchoesToFrameConverterTask.hpp
@@ -42,6 +42,7 @@ namespace radar_base {
         std::vector<uint8_t> m_echoes;
         std::unique_ptr<EchoToImageLUT> m_lut;
         cv::Mat m_cv_frame;
+        cv::Mat m_cv_frame_monochrome;
         RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> m_output_frame;
 
     protected:

--- a/tasks/EchoesToFrameConverterTask.hpp
+++ b/tasks/EchoesToFrameConverterTask.hpp
@@ -34,10 +34,10 @@ namespace radar_base {
         friend class EchoesToFrameConverterTaskBase;
 
     private:
-        int m_current_sweep_size = 0;
-        int m_current_num_angles = 0;
         float m_current_range = 0;
-        base::Time m_last_sample;
+        base::Time m_frame_output_deadline;
+        base::Angle m_yaw_correction;
+        RadarFrameExportConfig m_export_config;
 
         std::vector<uint8_t> m_echoes;
         std::unique_ptr<EchoToImageLUT> m_lut;
@@ -45,6 +45,11 @@ namespace radar_base {
         RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> m_output_frame;
 
     protected:
+        void echoCallback(const base::Time& ts, const radar_base::Radar& echo_sample);
+        void sensor2ref_poseCallback(const base::Time& ts,
+            const base::samples::RigidBodyState& sensor2ref_pose_sample);
+        void resetEchoMemory(std::size_t size);
+
     public:
         /** TaskContext constructor for EchoesToFrameConverterTask
          * \param name Name of the task. This name needs to be unique to make it
@@ -116,13 +121,15 @@ namespace radar_base {
          */
         void cleanupHook();
 
-        void updateLookUpTable(RadarFrameExportConfig config);
+        void updateLookUpTable(unsigned int num_sweeps,
+            unsigned int sweep_size,
+            RadarFrameExportConfig const& config);
 
         void addEchoesToFrame(Radar const& echo, base::Angle yaw_correction);
 
         void publishFrame();
 
-        void configureOutput(RadarFrameExportConfig config);
+        void configureOutput(RadarFrameExportConfig const& config);
     };
 }
 

--- a/test/echoes_to_frame_converter_task_test.rb
+++ b/test/echoes_to_frame_converter_task_test.rb
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
 
+require "syskit/aggregator/test_helpers"
+
 using_task_library "radar_base"
 import_types_from "radar_base"
 import_types_from "base"
 
+DEG2RAD = Math::PI / 180
+
 describe OroGen.radar_base.EchoesToFrameConverterTask do
     run_live
 
+    include Syskit::Aggregator::TestHelpers
+
+    attr_reader :task
+    before do
+        @task = create_configure_task
+    end
+
     it "starts and outputs single radar data" do
-        task = create_configure_task
         syskit_start(task)
 
-        output = expect_execution do
-            syskit_write task.echo_port, @echo
-        end.to do
-            have_one_new_sample(task.frame_port)
-        end
+        write_pose(task, @sensor2ref_pose)
+        output = write_echo(task, @echo)
+
         expected = File.binread(File.join(__dir__, "image1.bin"))
 
         assert_equal expected, output.image.to_a.to_s,
@@ -23,16 +31,13 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
     end
 
     it "starts and outputs multiple radar data for a single frame" do
-        task = create_configure_task
-        task.poll do
-            syskit_write task.echo_port, @echo_part1
-            syskit_write task.echo_port, @echo_part2
-        end
         syskit_start(task)
 
-        output = expect_execution.to do
-            have_one_new_sample(task.frame_port)
-        end
+        write_pose(task, @sensor2ref_pose)
+        now = Time.now
+        write_echo(task, @echo_part1, now)
+        output = write_echo(task, @echo_part2, now + 1)
+
         expected = File.binread(File.join(__dir__, "image2.bin"))
 
         assert_equal expected, output.image.to_a.to_s,
@@ -40,15 +45,9 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
     end
 
     it "starts and outputs radar data with a negative stepsize" do
-        task = create_configure_task
-        task.poll do
-            syskit_write task.echo_port, @echo_inverted
-        end
         syskit_start(task)
-
-        output = expect_execution.to do
-            have_one_new_sample(task.frame_port)
-        end
+        write_pose(task, @sensor2ref_pose)
+        output = write_echo(task, @echo_inverted)
         expected = File.binread(File.join(__dir__, "image1.bin"))
 
         assert_equal expected, output.image.to_a.to_s,
@@ -56,46 +55,50 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
     end
 
     it "it rotates sample 90 degrees 5 times" do
-        task = create_configure_task
         syskit_start(task)
 
         arrow = []
         64.times { arrow.concat [0] }
         arrow[0..7] = [0, 255, 0, 255, 0, 255, 0, 255]
-        @echo_rotation[:sweep_data] = arrow
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(1, 0, 0, 0)
+        @echo_rotation.sweep_data = arrow
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(0, Eigen::Vector3.UnitZ)
 
         write_pose(task, @sensor2ref_pose)
         output1 = write_echo(task, @echo_rotation)
 
         arrow[0..7] = [0, 0, 0, 0, 0, 0, 0, 0]
         arrow[48..55] = [0, 255, 0, 255, 0, 255, 0, 255]
-        @echo_rotation[:sweep_data] = arrow
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(0.7071068, 0, 0, 0.7071068)
+        @echo_rotation.sweep_data = arrow
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(90 * DEG2RAD, Eigen::Vector3.UnitZ)
 
         write_pose(task, @sensor2ref_pose)
         output2 = write_echo(task, @echo_rotation)
 
         arrow[48..55] = [0, 0, 0, 0, 0, 0, 0, 0]
         arrow[32..39] = [0, 255, 0, 255, 0, 255, 0, 255]
-        @echo_rotation[:sweep_data] = arrow
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(0, 0, 0, 1)
+        @echo_rotation.sweep_data = arrow
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(180 * DEG2RAD, Eigen::Vector3.UnitZ)
 
         write_pose(task, @sensor2ref_pose)
         output3 = write_echo(task, @echo_rotation)
 
         arrow[32..39] = [0, 0, 0, 0, 0, 0, 0, 0]
         arrow[16..23] = [0, 255, 0, 255, 0, 255, 0, 255]
-        @echo_rotation[:sweep_data] = arrow
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(-0.7071068, 0, 0, 0.7071068)
+        @echo_rotation.sweep_data = arrow
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(270 * DEG2RAD, Eigen::Vector3.UnitZ)
 
         write_pose(task, @sensor2ref_pose)
         output4 = write_echo(task, @echo_rotation)
 
         arrow[16..23] = [0, 0, 0, 0, 0, 0, 0, 0]
         arrow[0..7] = [0, 255, 0, 255, 0, 255, 0, 255]
-        @echo_rotation[:sweep_data] = arrow
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(1, 0, 0, 0)
+        @echo_rotation.sweep_data = arrow
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(0, Eigen::Vector3.UnitZ)
 
         write_pose(task, @sensor2ref_pose)
         output5 = write_echo(task, @echo_rotation)
@@ -115,10 +118,13 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
         samples = 4
         sweep_length = 8
         task.properties.export_config = {
-            time_between_frames: Time.at(0.0001),
+            time_between_frames: Time.at(0),
             output_image_size: 512,
             beam_width: 1 / samples * 2 * Math::PI
         }
+        task.properties.stream_aligner_status_period = 0
+        task.properties.echo_period = 0.02
+        task.properties.sensor2ref_pose_period = 0.01
         pattern = [0, 255]
         pattern1 = []
         pattern2 = []
@@ -133,8 +139,7 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
         data = pattern1 + pattern2
         (samples / 2).times { input.concat(data) }
         (samples / 2).times { input_inverted.concat(pattern2 + pattern1) }
-        @echo = Types.radar_base.Radar.new
-        @echo = {
+        @echo = Types.radar_base.Radar.new(
             timestamp: Time.now,
             range: 2.0,
             step_angle: {
@@ -146,10 +151,9 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
             sweep_length: sweep_length,
             sweep_timestamps: times_array,
             sweep_data: input
-        }
+        )
 
-        @echo_inverted = Types.radar_base.Radar.new
-        @echo_inverted = {
+        @echo_inverted = Types.radar_base.Radar.new(
             timestamp: Time.now,
             range: 2.0,
             step_angle: {
@@ -161,10 +165,9 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
             sweep_length: sweep_length,
             sweep_timestamps: times_array,
             sweep_data: input
-        }
+        )
 
-        @echo_part1 = Types.radar_base.Radar.new
-        @echo_part1 = {
+        @echo_part1 = Types.radar_base.Radar.new(
             timestamp: Time.now,
             range: 2.0,
             step_angle: {
@@ -176,10 +179,9 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
             sweep_length: sweep_length,
             sweep_timestamps: times_array,
             sweep_data: input
-        }
+        )
 
-        @echo_part2 = Types.radar_base.Radar.new
-        @echo_part2 = {
+        @echo_part2 = Types.radar_base.Radar.new(
             timestamp: Time.now,
             range: 2.0,
             step_angle: {
@@ -191,9 +193,8 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
             sweep_length: sweep_length,
             sweep_timestamps: times_array,
             sweep_data: input
-        }
-        @echo_rotation = Types.radar_base.Radar.new
-        @echo_rotation = {
+        )
+        @echo_rotation = Types.radar_base.Radar.new(
             timestamp: Time.now,
             range: 2.0,
             step_angle: {
@@ -205,14 +206,15 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
             sweep_length: sweep_length,
             sweep_timestamps: times_array * 2,
             sweep_data: []
-        }
+        )
 
         @sensor2ref_pose = Types.base.samples.RigidBodyState.Invalid
         @sensor2ref_pose.sourceFrame = "world"
         @sensor2ref_pose.targetFrame = "radar"
         @sensor2ref_pose.time = time
         @sensor2ref_pose.position = Eigen::Vector3.new(0, 0, 0)
-        @sensor2ref_pose.orientation = Eigen::Quaternion.new(0.7071068, 0, 0, 0.7071068)
+        @sensor2ref_pose.orientation =
+            Eigen::Quaternion.from_angle_axis(0, Eigen::Vector3.UnitZ)
         task
     end
 
@@ -223,18 +225,24 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
     end
 
     def write_pose(task, pose)
-        expect_execution do
-            syskit_write task.sensor2ref_pose_port, pose
-        end.to do
-            have_one_new_sample(task.frame_port)
-        end
+        pose.time = Time.now
+        stream_aligner_write(
+            task,
+            task.sensor2ref_pose_port,
+            pose,
+            sample_time_field: "time"
+        )
     end
 
-    def write_echo(task, echo)
-        expect_execution do
-            syskit_write task.echo_port, echo
-        end.to do
-            have_one_new_sample(task.frame_port)
+    def write_echo(task, echo, time = Time.now)
+        echo.timestamp = time
+        stream_aligner_write(
+            task,
+            task.echo_port,
+            echo,
+            sample_time_field: "timestamp"
+        ) do
+            have_one_new_sample task.frame_port
         end
     end
 end

--- a/test/echoes_to_frame_converter_task_test.rb
+++ b/test/echoes_to_frame_converter_task_test.rb
@@ -18,6 +18,26 @@ describe OroGen.radar_base.EchoesToFrameConverterTask do
         @task = create_configure_task
     end
 
+    it "does not start output with only sensor2ref input" do
+        syskit_start(task)
+
+        expect_execution
+            .poll { syskit_write task.sensor2ref_pose_port, @sensor2ref_pose }
+            .to do
+                have_no_new_sample(task.frame_port, at_least_during: 5)
+            end
+    end
+
+    it "does not start output with only echo input" do
+        syskit_start(task)
+
+        expect_execution
+            .poll { syskit_write task.echo_port, @echo }
+            .to do
+                have_no_new_sample(task.frame_port, at_least_during: 5)
+            end
+    end
+
     it "starts and outputs single radar data" do
         syskit_start(task)
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/drivers-orogen-aggregator/pull/8
<!--
[sc-67805] 
-->
### What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

1. Probably fix the heisenbug on `it "starts and outputs single radar data"` by outputting just after receiving valid pose and echo data. It is blocking another PR of mine
    1. The stream aligner although being the right way to make this component was not strictly necessary, but it would help with testing so we took the opportunity 
1. I can't read quaternions, so I made a marginal improvement on test readability